### PR TITLE
Refactor this command

### DIFF
--- a/package.json
+++ b/package.json
@@ -861,9 +861,9 @@
         }
       },{
         "key": "ctrl+alt+shift+t",
-        "mac": "ctrl+alt+shift+t",
+        "mac": "alt+t",
         "command": "editor.action.refactor",
-        "when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly"
+        "when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly",
         "jetbrains": "Refactor this (selected expressions or statements)"
       },{
         "key": "alt+0",

--- a/package.json
+++ b/package.json
@@ -859,8 +859,13 @@
           "kind": "refactor.extract.constant",
           "apply": "ifSingle"
         }
-      },
-      {
+      },{
+        "key": "ctrl+alt+shift+t",
+        "mac": "ctrl+alt+shift+t",
+        "command": "editor.action.refactor",
+        "when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly"
+        "jetbrains": "Refactor this (selected expressions or statements)"
+      },{
         "key": "alt+0",
         "mac": "cmd+0",
         "command": "workbench.actions.view.problems",

--- a/package.json
+++ b/package.json
@@ -861,7 +861,7 @@
         }
       },{
         "key": "ctrl+alt+shift+t",
-        "mac": "alt+t",
+        "mac": "ctrl+t",
         "command": "editor.action.refactor",
         "when": "editorHasCodeActionsProvider && editorTextFocus && !editorReadonly",
         "jetbrains": "Refactor this (selected expressions or statements)"


### PR DESCRIPTION
Adds missing `refactor this` command with key stroke `ctrl+alt+shift+t`.
**Note**: <s>There is no corresponding keybinding for the mac keyboard specified by JetBrains so I left it the same as for windows.
I wasn't sure if leaving it empty wouldn't break anything.</s>

[Jet Brains default keybindings reference.pdf](https://resources.jetbrains.com/storage/products/intellij-idea/docs/IntelliJIDEA_ReferenceCard.pdf)

